### PR TITLE
Cycletime stats

### DIFF
--- a/lib/jirametrics/cycletime_histogram.rb
+++ b/lib/jirametrics/cycletime_histogram.rb
@@ -55,7 +55,7 @@ class CycletimeHistogram < ChartBase
     count_hash
   end
 
-  def stats_for histogram_data:
+  def stats_for histogram_data:, percentiles:[]
     return {} if histogram_data.empty?
 
     total_values = histogram_data.values.sum
@@ -69,9 +69,27 @@ class CycletimeHistogram < ChartBase
     max_freq = sorted_histogram[-1][1]
     mode = sorted_histogram.select { |v,f| f == max_freq }
 
+    # Calculate percentiles
+    sorted_values = histogram_data.keys.sort
+    cumulative_counts = {}
+    cumulative_sum = 0
+
+    sorted_values.each do |value|
+      cumulative_sum += histogram_data[value]
+      cumulative_counts[value] = cumulative_sum
+    end
+
+    percentile_results = {}
+    percentiles.each do |percentile|
+      rank = (percentile / 100.0) * total_values
+      percentile_value = sorted_values.find { |value| cumulative_counts[value] >= rank }
+      percentile_results[percentile] = percentile_value
+    end
+
     { 
       average: average, 
-      mode: mode.length == 1? mode[0][0] : mode.collect{|x| x[0] }.sort 
+      mode: mode.length == 1? mode[0][0] : mode.collect{|x| x[0] }.sort,
+      percentiles: percentile_results
     } 
   end
 

--- a/lib/jirametrics/cycletime_histogram.rb
+++ b/lib/jirametrics/cycletime_histogram.rb
@@ -64,7 +64,15 @@ class CycletimeHistogram < ChartBase
     weighted_sum = histogram_data.reduce(0) { |sum, (value, frequency)| sum + value * frequency }
     average = total_values != 0? weighted_sum.to_f / total_values : 0
 
-    { average: average } 
+     # Find the mode (or modes!)
+    sorted_histogram = histogram_data.sort_by{ |value, frequency| frequency }
+    max_freq = sorted_histogram[-1][1]
+    mode = sorted_histogram.select { |v,f| f == max_freq }
+
+    { 
+      average: average, 
+      mode: mode.length == 1? mode[0][0] : mode.collect{|x| x[0] }.sort 
+    } 
   end
 
   def data_set_for histogram_data:, label:, color:

--- a/lib/jirametrics/cycletime_histogram.rb
+++ b/lib/jirametrics/cycletime_histogram.rb
@@ -55,6 +55,18 @@ class CycletimeHistogram < ChartBase
     count_hash
   end
 
+  def stats_for histogram_data:
+    return {} if histogram_data.empty?
+
+    total_values = histogram_data.values.sum
+
+    # Calculate the average
+    weighted_sum = histogram_data.reduce(0) { |sum, (value, frequency)| sum + value * frequency }
+    average = total_values != 0? weighted_sum.to_f / total_values : 0
+
+    { average: average } 
+  end
+
   def data_set_for histogram_data:, label:, color:
     keys = histogram_data.keys.sort
     {

--- a/spec/cycletime_histogram_spec.rb
+++ b/spec/cycletime_histogram_spec.rb
@@ -31,18 +31,19 @@ describe CycletimeHistogram do
     end
 
     it 'calculates the average' do
-      expect_average({ 4 => 2, 5 => 3 }).to eq((4*2 + 5*3).to_f/(2 + 3))
+      expect_average({ 4 => 2, 5 => 3, 10 => 0 }).to eq((4*2 + 5*3).to_f/(2 + 3))
       expect_average({ 10 => 1 }).to eq(10)
       expect_average({ 5 => 5 }).to eq(5)
-      
+
       expect_average({ 1 => 0 }).to eq(0)
       expect_average({ 0 => 0 }).to eq(0)
     end
 
     it 'calculates the mode' do
-      # expect_mode({ 1 => 2, 2 => 5, 3 => 1 }).to eq(2)
-      # expect_mode({ 5 => 15 }).to eq(5)
-      #expect_mode({ 1 => 5, 2 => 1, 3 => 5 }).to eq([1, 3]) 
+      expect_mode({ 1 => 2, 2 => 5, 3 => 1 }).to eq(2)
+      expect_mode({ 5 => 1 }).to eq(5)
+      expect_mode({ 1 => 5, 2 => 1, 3 => 5 }).to eq([1, 3]) # multi-modal distribution case
+      expect_mode({ 5 => 1, 1 => 1 }).to eq([1, 5])
     end
 
     def expect_mode(histogram_data)

--- a/spec/cycletime_histogram_spec.rb
+++ b/spec/cycletime_histogram_spec.rb
@@ -2,6 +2,7 @@
 
 require './spec/spec_helper'
 
+
 describe CycletimeHistogram do
   let(:board) { load_complete_sample_board }
   let(:issue1) { load_issue 'SP-1', board: board }
@@ -21,6 +22,37 @@ describe CycletimeHistogram do
         [issue10, '2022-01-01', '2022-01-01T01:00:00']
       ]
       expect(chart.histogram_data_for issues: [issue1, issue2, issue10]).to eq({ 4 => 2, 1 => 1 })
+    end
+  end
+
+  context 'stats_for' do
+    it 'handles no issues' do
+      expect(chart.stats_for histogram_data:{}).to eq({})
+    end
+
+    it 'calculates the average' do
+      expect_average({ 4 => 2, 5 => 3 }).to eq((4*2 + 5*3).to_f/(2 + 3))
+      expect_average({ 10 => 1 }).to eq(10)
+      expect_average({ 5 => 5 }).to eq(5)
+      
+      expect_average({ 1 => 0 }).to eq(0)
+      expect_average({ 0 => 0 }).to eq(0)
+    end
+
+    it 'calculates the mode' do
+      # expect_mode({ 1 => 2, 2 => 5, 3 => 1 }).to eq(2)
+      # expect_mode({ 5 => 15 }).to eq(5)
+      #expect_mode({ 1 => 5, 2 => 1, 3 => 5 }).to eq([1, 3]) 
+    end
+
+    def expect_mode(histogram_data)
+      stats = chart.stats_for histogram_data:histogram_data
+      expect(stats[:mode])
+    end
+
+    def expect_average(histogram_data)
+      stats = chart.stats_for histogram_data:histogram_data
+      expect(stats[:average])
     end
   end
 

--- a/spec/cycletime_histogram_spec.rb
+++ b/spec/cycletime_histogram_spec.rb
@@ -42,8 +42,32 @@ describe CycletimeHistogram do
     it 'calculates the mode' do
       expect_mode({ 1 => 2, 2 => 5, 3 => 1 }).to eq(2)
       expect_mode({ 5 => 1 }).to eq(5)
-      expect_mode({ 1 => 5, 2 => 1, 3 => 5 }).to eq([1, 3]) # multi-modal distribution case
-      expect_mode({ 5 => 1, 1 => 1 }).to eq([1, 5])
+
+      # Multi-modal distribution cases
+      expect_mode({ 1 => 5, 2 => 1, 3 => 5 }).to eq([1, 3])
+      expect_mode({ 5 => 1, 1 => 1 }).to eq([1, 5]) # make sure values come out sorted
+    end
+
+    it 'ignores percentiles if not requested' do
+      stats = chart.stats_for histogram_data: { 1 => 1, 2 => 1}
+      expect(stats[:percentiles]).to eq({})
+    end
+
+    it 'calculates percentiles' do
+      expect_percentiles(
+        { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1}, [30, 50, 75, 99, 100] ).to eq(
+        {30 => 3, 50 => 5, 75 => 8, 99 => 10, 100 => 10})
+
+        expect_percentiles({ 3=>1, 6=>1, 7=>10, 15=> 1, 20 => 1}, [50, 75, 92]).to eq({50 => 7, 75 => 7, 92 => 15 })
+
+        expect_percentiles({ 1=>1, 2=>1}, [101]).to eq({101 => nil})
+        expect_percentiles({ 1=>1, 2=>1}, [0]).to eq({0 => 1})
+
+    end
+
+    def expect_percentiles(histogram_data, percentiles)
+      stats = chart.stats_for histogram_data:histogram_data, percentiles:percentiles
+      expect(stats[:percentiles])
     end
 
     def expect_mode(histogram_data)


### PR DESCRIPTION
Added a table under the Cycletime Histogram to show average, mode, and percentiles per issue type.

<img width="354" alt="image" src="https://github.com/user-attachments/assets/cf00758a-3d6a-4779-8e6e-c8642d5e7131" />

**Things still to do:**
- make this configurable (on/off switch)
- add styling to the table (ugly default lines for now)
- make the percentiles configurable (hard-coded right now to 3 values)
- ability to collapse the section in the report (similar to the Quality Report), to hide the table by default
- configurable title (?)
- more testing (especially with multiple issue types)