### PR TITLE
Cycletime stats

### DIFF
--- a/lib/jirametrics/cycletime_histogram.rb
+++ b/lib/jirametrics/cycletime_histogram.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'jirametrics/groupable_issue_chart'
 
@@ -48,43 +49,7 @@ class CycletimeHistogram < ChartBase
 
     return "<h1>#{@header_text}</h1>No data matched the selected criteria. Nothing to show." if data_sets.empty?
 
-    wrap_and_render(binding, __FILE__) << render_stats(the_stats)
-  end
-
-  def render_stats(stats)
-    result = <<~HTML
-      <p>STATS</p>
-      <div>
-       <table class="standard">
-        <tr>
-          <th>Issue Type</th>
-          <th>Avg</th>
-          <th>Mode</th>
-          <th>50th</th>
-          <th>85th</th>
-          <th>95th</th>
-        </tr>
-    HTML
-
-    stats.each do |k, v|
-      result << <<~HTML
-        <tr>
-          <td>#{k}</td>
-          <td>#{sprintf('%.2f', v[:average])}</td>
-          <td>#{v[:mode]}</td>
-          <td>#{v[:percentiles][50]}</td>
-          <td>#{v[:percentiles][85]}</td>
-          <td>#{v[:percentiles][95]}</td>
-        </tr>
-      HTML
-    end
-
-    result << <<~HTML
-      </table>
-      </div>
-    HTML
-
-    result
+    wrap_and_render(binding, __FILE__) 
   end
 
   def histogram_data_for issues:

--- a/lib/jirametrics/html/cycletime_histogram.erb
+++ b/lib/jirametrics/html/cycletime_histogram.erb
@@ -1,6 +1,29 @@
 <div class="chart">
   <canvas id="<%= chart_id %>" width="<%= canvas_width %>" height="<%= canvas_height %>"></canvas>
 </div>
+<p><b>STATS</b></p>
+<div>
+   <table class="standard">
+    <tr>
+      <th>Issue Type</th>
+      <th>Avg</th>
+      <th>Mode</th>
+      <th>50th</th>
+      <th>85th</th>
+      <th>95th</th>
+    </tr>
+    <% the_stats.each do |k, v| %>
+        <tr>
+          <td><%= k %></td>
+          <td><%= sprintf('%.2f', v[:average]) %></td>
+          <td><%= v[:mode] %></td>
+          <td><%= v[:percentiles][50] %></td>
+          <td><%= v[:percentiles][85] %></td>
+          <td><%= v[:percentiles][95] %></td>
+        </tr>
+     <% end %>
+   </table>
+</div>
 <script>
 new Chart(document.getElementById('<%= chart_id %>').getContext('2d'),
 {

--- a/lib/jirametrics/html/cycletime_histogram.erb
+++ b/lib/jirametrics/html/cycletime_histogram.erb
@@ -1,28 +1,47 @@
 <div class="chart">
   <canvas id="<%= chart_id %>" width="<%= canvas_width %>" height="<%= canvas_height %>"></canvas>
 </div>
-<p><b>STATS</b></p>
-<div>
-   <table class="standard">
-    <tr>
-      <th>Issue Type</th>
-      <th>Avg</th>
-      <th>Mode</th>
-      <th>50th</th>
-      <th>85th</th>
-      <th>95th</th>
-    </tr>
-    <% the_stats.each do |k, v| %>
-        <tr>
-          <td><%= k %></td>
-          <td><%= sprintf('%.2f', v[:average]) %></td>
-          <td><%= v[:mode] %></td>
-          <td><%= v[:percentiles][50] %></td>
-          <td><%= v[:percentiles][85] %></td>
-          <td><%= v[:percentiles][95] %></td>
-        </tr>
-     <% end %>
-   </table>
+<%
+  link_id = next_id
+  issues_id = next_id
+%>
+[<a id='<%= link_id %>' href="#" onclick='expand_collapse("<%= link_id %>", "<%= issues_id %>"); return false;'>Show details</a>]
+<div id="<%= issues_id %>" style="display: none;">
+  <div>
+     <table class="standard">
+      <tr>
+        <th>Issue Type</th>
+        <th>Avg</th>
+        <th>Mode</th>
+        <th>50th</th>
+        <th>85th</th>
+        <th>95th</th>
+      </tr>
+      <% the_stats.each do |k, v| %>
+          <tr>
+            <td><%= k %></td>
+            <td><%= sprintf('%.2f', v[:average]) %></td>
+            <td><%= v[:mode] %></td>
+            <td><%= v[:percentiles][50] %></td>
+            <td><%= v[:percentiles][85] %></td>
+            <td><%= v[:percentiles][95] %></td>
+          </tr>
+       <% end %>
+     </table>
+  </div>
+  <div>
+    <p>These statistics help understand the <i>"shape"</i> of the cycletime histogram distribution, to help us with predictions.</p>
+    <ul>
+      <li><b>Average:</b> the arithmetic mean of the data set. Useful as a <i>"typical representative"</i> of the complete set.</li>
+      <li><b>Mode:</b> the most repeated value in the data set. This is the one we're most likely to remember. </li>
+      <li><b>Percentiles:</b> they partition the data set. If X is the Nth percentile, it means that N% of cycletime values are X or less. Typical percentiles of interest are:</li>
+      <ul>
+        <li><b>50%</b>: also known as the <b>Median</b>. Useful to establish short feedback loops, to monitor that it's not drifting to the right.</li>
+        <li><b>85%</b>: useful to establish service level expectations, accounting for rare events..</li>
+        <li><b>95% (or higher)</b>: useful to establish high certainty expectations.</li>
+      </ul>
+    </ul>
+  </div>
 </div>
 <script>
 new Chart(document.getElementById('<%= chart_id %>').getContext('2d'),


### PR DESCRIPTION
Moved the HTML out of ruby files and into the ERB file. The stats table is now hidden by default, like in other charts, and it includes an explanatory legend for the various values.