### PR TITLE
Configurable percentiles

### DIFF
--- a/lib/jirametrics/cycletime_histogram.rb
+++ b/lib/jirametrics/cycletime_histogram.rb
@@ -5,9 +5,12 @@ require 'jirametrics/groupable_issue_chart'
 class CycletimeHistogram < ChartBase
   include GroupableIssueChart
   attr_accessor :possible_statuses
+  attr_accessor :percentiles
 
   def initialize block
     super()
+
+    @percentiles = [50, 85, 98]
 
     header_text 'Cycletime Histogram'
     description_text <<-HTML
@@ -26,6 +29,10 @@ class CycletimeHistogram < ChartBase
     end
   end
 
+  def use_percentiles percentiles
+    @percentiles = percentiles 
+  end
+
   def run
     stopped_issues = completed_issues_in_range include_unstarted: true
 
@@ -38,7 +45,7 @@ class CycletimeHistogram < ChartBase
     data_sets = rules_to_issues.keys.collect do |rules|
       the_issue_type = rules.label
       the_histogram = histogram_data_for(issues: rules_to_issues[rules])
-      the_stats[the_issue_type] = stats_for histogram_data:the_histogram, percentiles:[50, 85, 95]
+      the_stats[the_issue_type] = stats_for histogram_data:the_histogram, percentiles:@percentiles
 
       data_set_for(
         histogram_data: the_histogram,

--- a/lib/jirametrics/html/cycletime_histogram.erb
+++ b/lib/jirametrics/html/cycletime_histogram.erb
@@ -13,18 +13,18 @@
         <th>Issue Type</th>
         <th>Avg</th>
         <th>Mode</th>
-        <th>50th</th>
-        <th>85th</th>
-        <th>95th</th>
+        <% percentiles.each do |p| %>
+           <th><%= p %>th</th>
+        <% end %>
       </tr>
       <% the_stats.each do |k, v| %>
           <tr>
             <td><%= k %></td>
             <td><%= sprintf('%.2f', v[:average]) %></td>
             <td><%= v[:mode] %></td>
-            <td><%= v[:percentiles][50] %></td>
-            <td><%= v[:percentiles][85] %></td>
-            <td><%= v[:percentiles][95] %></td>
+            <% percentiles.each do |p| %>
+               <td><%= v[:percentiles][p] %></td>
+            <% end %>
           </tr>
        <% end %>
      </table>
@@ -38,7 +38,7 @@
       <ul>
         <li><b>50%</b>: also known as the <b>Median</b>. Useful to establish short feedback loops, to monitor that it's not drifting to the right.</li>
         <li><b>85%</b>: useful to establish service level expectations, accounting for rare events..</li>
-        <li><b>95% (or higher)</b>: useful to establish high certainty expectations.</li>
+        <li><b>98% (or higher)</b>: useful to gauge worst case expectations..</li>
       </ul>
     </ul>
   </div>


### PR DESCRIPTION
Percentiles can now be specified in the config file:

```
        cycletime_histogram do
          use_percentiles [37, 50, 63, 75]
        end
```