### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.beads
+.claude
+coverage
+tmp
+vendor/bundle
+node_modules
+output
+*.log
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ spec/tmp/
 *.gem
 *.log
 extra.css
+.idea
 
 # Node.js dependencies
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:4.0-slim
+
+ENV APP_HOME=/app
+ENV BUNDLE_PATH=/usr/local/bundle
+ENV RUBYLIB=/app/lib
+
+WORKDIR ${APP_HOME}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    ca-certificates \
+    libyaml-dev \
+    pkg-config \
+    graphviz \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile jirametrics.gemspec ./
+COPY lib ./lib
+COPY bin ./bin
+
+RUN chmod +x ./bin/jirametrics ./bin/jirametrics-mcp \
+  && bundle install
+
+ENTRYPOINT ["bundle", "exec", "ruby", "-I/app/lib", "/app/bin/jirametrics"]
+CMD ["--help"]


### PR DESCRIPTION
The motivation is to simplify the tool running.
So now the run looks like:
```
docker run --rm \
  -v "./jira_config.json:/workspace/jira_config.json" \
  -v "./config.rb:/workspace/config.rb" \
  -v "./target/:/workspace/target/" \
  jirametrics:local \
  go --config /workspace/config.rb
```
Also, it would be great if you can setup new Docker image auto-build when you create a new release.